### PR TITLE
Fixed 1 issue of type: PYTHON_E225 throughout 1 file in repo.

### DIFF
--- a/training/inceptionv3_transfer/train_initialization.py
+++ b/training/inceptionv3_transfer/train_initialization.py
@@ -47,7 +47,7 @@ x = Dropout(0.25)(x)
 predictions = Dense(constants.NUM_CLASSES,  kernel_initializer="glorot_uniform", activation='softmax')(x)
 
 print('Stacking New Layers')
-model=Model(inputs = conv_base.input, outputs=predictions)
+model = Model(inputs = conv_base.input, outputs=predictions)
 
 # Load checkpoint if one is found
 if os.path.exists(weights_file):


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.