### PR TITLE
Adds EfficientNet B0 Model to training scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ images/**
 # Ignore my Visual Studio solution for editing python
 NSFWModel/**
 trained_models/**
+training/train_best_models.cmd

--- a/training/train_all_models.cmd
+++ b/training/train_all_models.cmd
@@ -4,9 +4,20 @@
 :: https://tfhub.dev/google/imagenet/resnet_v2_50/classification/4
 :: https://tfhub.dev/google/imagenet/inception_v3/classification/4
 :: https://tfhub.dev/google/imagenet/nasnet_mobile/classification/4
+:: https://tfhub.dev/tensorflow/efficientnet/b0/classification/1
 ::
 :: If you get CUDA_OUT_OF_MEMORY crash, you need to pass --batch_size NUMBER, reducing until you don't get this error.
 :: It is advised by Google not to have a batch size < 8.
+
+:: Train EfficientNet B0
+python make_nsfw_model.py --image_dir %cd%\..\images --image_size 224 --saved_model_dir %cd%\..\trained_models\efficientnet_b0_224 --labels_output_file %cd%\..\trained_models\efficientnet_b0_224\class_labels.txt --tfhub_module https://tfhub.dev/tensorflow/efficientnet/b0/classification/1 --tflite_output_file %cd%\..\trained_models\efficientnet_b0_224\saved_model.tflite --train_epochs 5 --batch_size 16 --do_fine_tuning --learning_rate 0.05 --dropout_rate 0.0 --momentum 0.9
+:: Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training.
+:: tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve %cd%\..\trained_models\efficientnet_b0_224 %cd%\..\trained_models\efficientnet_b0_224\web_model
+:: Or, for a quantized (1 byte) version
+:: tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve %cd%\..\trained_models\efficientnet_b0_224 %cd%\..\trained_models\efficientnet_b0_224\web_model_quantized --quantization_bytes 1
+
+:: Wait for Python/CUDA/GPU to recover. Seems to die without this.
+Timeout /T 60 /Nobreak
 
 :: Train Mobilenet V2 140
 python make_nsfw_model.py --image_dir %cd%\..\images --image_size 224 --saved_model_dir %cd%\..\trained_models\mobilenet_v2_140_224 --labels_output_file %cd%\..\trained_models\mobilenet_v2_140_224\class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/mobilenet_v2_140_224/classification/4 --tflite_output_file %cd%\..\trained_models\mobilenet_v2_140_224\saved_model.tflite --train_epochs 5 --batch_size 32 --do_fine_tuning --learning_rate 0.001 --dropout_rate 0.0 --momentum 0.9

--- a/training/train_all_models.sh
+++ b/training/train_all_models.sh
@@ -5,9 +5,20 @@
 # https://tfhub.dev/google/imagenet/resnet_v2_50/classification/4
 # https://tfhub.dev/google/imagenet/inception_v3/classification/4
 # https://tfhub.dev/google/imagenet/nasnet_mobile/classification/4
+# https://tfhub.dev/tensorflow/efficientnet/b0/classification/1
 #
 # If you get CUDA_OUT_OF_MEMORY crash, you need to pass --batch_size NUMBER, reducing until you don't get this error.
 # It is advised by Google not to have a batch size < 8.
+
+# Train EfficientNet B0
+python3 make_nsfw_model.py --image_dir $PWD/../images --image_size 224 --saved_model_dir $PWD/../trained_models/efficientnet_b0_224 --labels_output_file $PWD/../trained_models/efficientnet_b0_224/class_labels.txt --tfhub_module https://tfhub.dev/tensorflow/efficientnet/b0/classification/1 --tflite_output_file $PWD/../trained_models/efficientnet_b0_224/saved_model.tflite --train_epochs 5 --batch_size 16 --do_fine_tuning --learning_rate 0.05 --dropout_rate 0.0 --momentum 0.9
+# Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training.
+# tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/efficientnet_b0_224 $PWD/../trained_models/efficientnet_b0_224/web_model
+# Or, for a quantized (1 byte) version
+# tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/efficientnet_b0_224 $PWD/../trained_models/efficientnet_b0_224/web_model_quantized --quantization_bytes 1
+
+# Wait for Python/CUDA/GPU to recover. Seems to die without this.
+sleep 60
 
 # Train Mobilenet V2 140
 python3 make_nsfw_model.py --image_dir $PWD/../images --image_size 224 --saved_model_dir $PWD/../trained_models/mobilenet_v2_140_224 --labels_output_file $PWD/../trained_models/mobilenet_v2_140_224/class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/mobilenet_v2_140_224/classification/4 --tflite_output_file $PWD/../trained_models/mobilenet_v2_140_224/saved_model.tflite --train_epochs 5 --batch_size 32 --do_fine_tuning --learning_rate 0.001 --dropout_rate 0.0 --momentum 0.9


### PR DESCRIPTION
Commit adds newly published EFNet B0 model to training scripts. No published model though. My experience is that this initial hub module has some issues, because I get worse classification results with this model than the Mobilenet model and that simply shouldn't be. Efnet is state of the art for accuracy. Anyway we'll want to keep an eye for efficientnet-lite b0 hub modules because they drastically reduce computation without sacrificing much accuracy.

I'm also attaching a newly trained mobilenet model zip. This is because I used another neural network to de-noise the training set and then re-trained. The "sexy" category had a few thousand files that were full blown pornography, and the pornography category had several thousand items that were not pornography at all.

I used a test set (that I'll also attach) to compare against. I notice in my work that "homework" image results resulted in a very high number of false positives with the old model. In fact the accuracy on the attached small validation set was ~88% with the old model. The accuracy with this newly attached model is ~94% on the same small validation set, a ~6% increase.

If nothing else, this demonstrates how drastically a noisy/poorly labelled training set can impact learning. 

The newly attached models' overall validation accuracy is 93.10%.

See:
```
Relying on driver to perform ptx compilation. This message will be only logged once.
Epoch 1/5
4320/4320 [==============================] - 1875s 434ms/step - loss: 1.0400 - accuracy: 0.8958 - val_loss: 0.9698 - val_accuracy: 0.9217
Epoch 2/5
4320/4320 [==============================] - 1824s 422ms/step - loss: 0.9493 - accuracy: 0.9352 - val_loss: 0.9528 - val_accuracy: 0.9280
Epoch 3/5
4320/4320 [==============================] - 1840s 426ms/step - loss: 0.9076 - accuracy: 0.9529 - val_loss: 0.9562 - val_accuracy: 0.9243
Epoch 4/5
4320/4320 [==============================] - 1809s 419ms/step - loss: 0.8761 - accuracy: 0.9655 - val_loss: 0.9525 - val_accuracy: 0.9249
Epoch 5/5
4320/4320 [==============================] - 1810s 419ms/step - loss: 0.8533 - accuracy: 0.9737 - val_loss: 0.9460 - val_accuracy: 0.9277

Second round of fine-tuning with LR decreased
Epoch 1/2
4320/4320 [==============================] - 1854s 429ms/step - loss: 0.8360 - accuracy: 0.9801 - val_loss: 0.9393 - val_accuracy: 0.9322
Epoch 2/2
4320/4320 [==============================] - 1825s 423ms/step - loss: 0.8206 - accuracy: 0.9884 - val_loss: 0.9458 - val_accuracy: 0.9310
```
As you can see, I did a second round of fine-tuning, dropping the LR even further than before and it paid off by rounding us up a percentage point. Additional experimentation seems to indicate that this is the peak we can achieve with the cleaned training data and fine tuning for this network architecture.