### PR TITLE
Adds a myriad of tunable training params

### DIFF
--- a/training/make_nsfw_model.py
+++ b/training/make_nsfw_model.py
@@ -128,6 +128,47 @@ flags.DEFINE_float(
 flags.DEFINE_bool(
 		"is_deprecated_tfhub_module", False,
 		"Whether or not the supplied TF hub module is old and from Tensorflow 1.")
+flags.DEFINE_float(
+		"label_smoothing", _DEFAULT_HPARAMS.label_smoothing,
+		"The degree of label smoothing to use.")
+flags.DEFINE_float(
+		"validation_split", _DEFAULT_HPARAMS.validation_split,
+		"The percentage of data to use for validation.")
+flags.DEFINE_string(
+    'optimizer', _DEFAULT_HPARAMS.optimizer,
+    'The name of the optimizer, one of "adadelta", "adagrad", "adam",'
+    '"ftrl", "momentum", "sgd" or "rmsprop".')
+flags.DEFINE_float(
+    'adadelta_rho', _DEFAULT_HPARAMS.adadelta_rho,
+    'The decay rate for adadelta.')
+flags.DEFINE_float(
+    'adagrad_initial_accumulator_value', _DEFAULT_HPARAMS.adagrad_initial_accumulator_value,
+    'Starting value for the AdaGrad accumulators.')
+flags.DEFINE_float(
+    'adam_beta1', _DEFAULT_HPARAMS.adam_beta1,
+    'The exponential decay rate for the 1st moment estimates.')
+flags.DEFINE_float(
+    'adam_beta2', _DEFAULT_HPARAMS.adam_beta2,
+    'The exponential decay rate for the 2nd moment estimates.')
+flags.DEFINE_float('opt_epsilon', _DEFAULT_HPARAMS.opt_epsilon, 'Epsilon term for the optimizer.')
+flags.DEFINE_float('ftrl_learning_rate_power', _DEFAULT_HPARAMS.ftrl_learning_rate_power,
+                          'The learning rate power.')
+flags.DEFINE_float(
+    'ftrl_initial_accumulator_value', _DEFAULT_HPARAMS.ftrl_initial_accumulator_value,
+    'Starting value for the FTRL accumulators.')
+flags.DEFINE_float(
+    'ftrl_l1', _DEFAULT_HPARAMS.ftrl_l1, 'The FTRL l1 regularization strength.')
+
+flags.DEFINE_float(
+    'ftrl_l2', _DEFAULT_HPARAMS.ftrl_l2, 'The FTRL l2 regularization strength.')
+flags.DEFINE_float('rmsprop_momentum', _DEFAULT_HPARAMS.rmsprop_momentum, 'Momentum.')
+flags.DEFINE_float('rmsprop_decay', _DEFAULT_HPARAMS.rmsprop_decay, 'Decay term for RMSProp.')
+flags.DEFINE_bool(
+		"do_data_augmentation", False,
+		"Whether or not to do data augmentation.")
+flags.DEFINE_bool(
+		"use_mixed_precision", False,
+		"Whether or not to use NVIDIA mixed precision. Requires NVIDIA card with at least compute level 7.0")
 
 FLAGS = flags.FLAGS
 
@@ -140,7 +181,26 @@ def _get_hparams_from_flags():
 			batch_size=FLAGS.batch_size,
 			learning_rate=FLAGS.learning_rate,
 			momentum=FLAGS.momentum,
-			dropout_rate=FLAGS.dropout_rate)
+			dropout_rate=FLAGS.dropout_rate,
+			label_smoothing=FLAGS.label_smoothing,
+			validation_split=FLAGS.validation_split,
+			optimizer=FLAGS.optimizer,
+			adadelta_rho=FLAGS.adadelta_rho,
+			adagrad_initial_accumulator_value=FLAGS.adagrad_initial_accumulator_value,
+			adam_beta1=FLAGS.adam_beta1,
+			adam_beta2=FLAGS.adam_beta2,
+			opt_epsilon=FLAGS.opt_epsilon,
+			ftrl_learning_rate_power=FLAGS.ftrl_learning_rate_power,
+			ftrl_initial_accumulator_value=FLAGS.ftrl_initial_accumulator_value,
+			ftrl_l1=FLAGS.ftrl_l1,
+			ftrl_l2=FLAGS.ftrl_l2,
+			rmsprop_momentum=FLAGS.rmsprop_momentum,
+			rmsprop_decay=FLAGS.rmsprop_decay,
+			do_data_augmentation=FLAGS.do_data_augmentation,
+			use_mixed_precision=FLAGS.use_mixed_precision
+			)
+			
+
 
 
 def _check_keras_dependencies():
@@ -177,6 +237,9 @@ def _assert_accuracy(train_result, assert_accuracy_at_least):
 def main(args):
 	"""Main function to be called by absl.app.run() after flag parsing."""
 	del args
+
+	#policy = mixed_precision.Policy('mixed_float16')
+	#mixed_precision.set_policy(policy)
 
 #tf.config.gpu.set_per_process_memory_fraction(0.75)
 #tf.config.gpu.set_per_process_memory_growth(False)

--- a/training/train_all_models.cmd
+++ b/training/train_all_models.cmd
@@ -1,27 +1,18 @@
 :: You can add more models types from here: https://tfhub.dev/s?module-type=image-classification&tf-version=tf2
 :: However, you must choose Tensorflow 2 models. V1 models will not work here.
-:: https://tfhub.dev/google/imagenet/mobilenet_v2_140_224/classification/4
-:: https://tfhub.dev/google/imagenet/resnet_v2_50/classification/4
-:: https://tfhub.dev/google/imagenet/inception_v3/classification/4
-:: https://tfhub.dev/google/imagenet/nasnet_mobile/classification/4
-:: https://tfhub.dev/tensorflow/efficientnet/b0/classification/1
+:: https://tfhub.dev/google/imagenet/mobilenet_v2_140_224/feature_vector/4
+:: https://tfhub.dev/google/imagenet/resnet_v2_50/feature_vector/4
+:: https://tfhub.dev/google/imagenet/inception_v3/feature_vector/4
+:: https://tfhub.dev/google/imagenet/nasnet_mobile/feature_vector/4
 ::
 :: If you get CUDA_OUT_OF_MEMORY crash, you need to pass --batch_size NUMBER, reducing until you don't get this error.
 :: It is advised by Google not to have a batch size < 8.
 
-:: Train EfficientNet B0
-python make_nsfw_model.py --image_dir %cd%\..\images --image_size 224 --saved_model_dir %cd%\..\trained_models\efficientnet_b0_224 --labels_output_file %cd%\..\trained_models\efficientnet_b0_224\class_labels.txt --tfhub_module https://tfhub.dev/tensorflow/efficientnet/b0/classification/1 --tflite_output_file %cd%\..\trained_models\efficientnet_b0_224\saved_model.tflite --train_epochs 5 --batch_size 16 --do_fine_tuning --learning_rate 0.05 --dropout_rate 0.0 --momentum 0.9
-:: Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training.
-:: tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve %cd%\..\trained_models\efficientnet_b0_224 %cd%\..\trained_models\efficientnet_b0_224\web_model
-:: Or, for a quantized (1 byte) version
-:: tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve %cd%\..\trained_models\efficientnet_b0_224 %cd%\..\trained_models\efficientnet_b0_224\web_model_quantized --quantization_bytes 1
-
-:: Wait for Python/CUDA/GPU to recover. Seems to die without this.
-Timeout /T 60 /Nobreak
+:: Note that we set all of our target epochs to over 9000. This is because the trainer just uses early stopping internally.
 
 :: Train Mobilenet V2 140
-python make_nsfw_model.py --image_dir %cd%\..\images --image_size 224 --saved_model_dir %cd%\..\trained_models\mobilenet_v2_140_224 --labels_output_file %cd%\..\trained_models\mobilenet_v2_140_224\class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/mobilenet_v2_140_224/classification/4 --tflite_output_file %cd%\..\trained_models\mobilenet_v2_140_224\saved_model.tflite --train_epochs 5 --batch_size 32 --do_fine_tuning --learning_rate 0.001 --dropout_rate 0.0 --momentum 0.9
-:: Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training.
+python make_nsfw_model.py --image_dir %cd%\..\images --image_size 224 --saved_model_dir %cd%\..\trained_models\mobilenet_v2_140_224 --labels_output_file %cd%\..\trained_models\mobilenet_v2_140_224\class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/mobilenet_v2_140_224/feature_vector/4 --tflite_output_file %cd%\..\trained_models\mobilenet_v2_140_224\saved_model.tflite --train_epochs 9001 --batch_size 32 --do_fine_tuning --dropout_rate 0.0 --label_smoothing=0.0 --validation_split=0.1 --do_data_augmentation=True --use_mixed_precision=True --rmsprop_momentum=0.0
+:: Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training. So make sure you perform this step after all your training is done, and then restore a GPU version of TF.
 :: tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve %cd%\..\trained_models\mobilenet_v2_140_224 %cd%\..\trained_models\mobilenet_v2_140_224\web_model
 :: Or, for a quantized (1 byte) version
 :: tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve %cd%\..\trained_models\mobilenet_v2_140_224 %cd%\..\trained_models\mobilenet_v2_140_224\web_model_quantized --quantization_bytes 1
@@ -30,8 +21,8 @@ python make_nsfw_model.py --image_dir %cd%\..\images --image_size 224 --saved_mo
 Timeout /T 60 /Nobreak
 
 :: Train Resnet V2 50
-python make_nsfw_model.py --image_dir %cd%\..\images --image_size 224 --saved_model_dir %cd%\..\trained_models\resnet_v2_50_224 --labels_output_file %cd%\..\trained_models\resnet_v2_50_224\class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/resnet_v2_50/classification/4 --tflite_output_file %cd%\..\trained_models\resnet_v2_50_224\saved_model.tflite --train_epochs 5 --batch_size 16 --do_fine_tuning --learning_rate 0.001 --dropout_rate 0.0 --momentum 0.9
-:: Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training.
+python make_nsfw_model.py --image_dir %cd%\..\images --image_size 224 --saved_model_dir %cd%\..\trained_models\resnet_v2_50_224 --labels_output_file %cd%\..\trained_models\resnet_v2_50_224\class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/resnet_v2_50/feature_vector/4 --tflite_output_file %cd%\..\trained_models\resnet_v2_50_224\saved_model.tflite --train_epochs 9001 --batch_size 16 --do_fine_tuning --learning_rate 0.001 --dropout_rate 0.0 --label_smoothing=0.0 --validation_split=0.1 --do_data_augmentation=True --use_mixed_precision=True --rmsprop_momentum=0.0
+:: Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training. So make sure you perform this step after all your training is done, and then restore a GPU version of TF.
 ::tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve %cd%\..\trained_models\resnet_v2_50_224 %cd%\..\trained_models\resnet_v2_50_224\web_model
 :: Or, for a quantized (1 byte) version
 ::tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve %cd%\..\trained_models\resnet_v2_50_224 %cd%\..\trained_models\resnet_v2_50_224\web_model_quantized --quantization_bytes 1
@@ -40,8 +31,8 @@ python make_nsfw_model.py --image_dir %cd%\..\images --image_size 224 --saved_mo
 Timeout /T 60 /Nobreak
 
 :: Train Inception V3
-python make_nsfw_model.py --image_dir %cd%\..\images --image_size 224 --saved_model_dir %cd%\..\trained_models\inception_v3_224 --labels_output_file %cd%\..\trained_models\inception_v3_224\class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/inception_v3/classification/4 --tflite_output_file %cd%\..\trained_models\inception_v3_224\saved_model.tflite --train_epochs 5 --batch_size 16 --do_fine_tuning --learning_rate 0.001 --dropout_rate 0.0 --momentum 0.9
-:: Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training.
+python make_nsfw_model.py --image_dir %cd%\..\images --image_size 224 --saved_model_dir %cd%\..\trained_models\inception_v3_224 --labels_output_file %cd%\..\trained_models\inception_v3_224\class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/inception_v3/feature_vector/4 --tflite_output_file %cd%\..\trained_models\inception_v3_224\saved_model.tflite --train_epochs 9001 --batch_size 16 --do_fine_tuning --learning_rate 0.001 --dropout_rate 0.0 --label_smoothing=0.0 --validation_split=0.1 --do_data_augmentation=True --use_mixed_precision=True --rmsprop_momentum=0.0
+:: Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training. So make sure you perform this step after all your training is done, and then restore a GPU version of TF.
 ::tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve %cd%\..\trained_models\inception_v3_224 %cd%\..\trained_models\inception_v3_224\web_model
 :: Or, for a quantized (1 byte) version
 ::tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve %cd%\..\trained_models\inception_v3_224 %cd%\..\trained_models\inception_v3_224\web_model_quantized --quantization_bytes 1
@@ -50,8 +41,8 @@ python make_nsfw_model.py --image_dir %cd%\..\images --image_size 224 --saved_mo
 Timeout /T 60 /Nobreak
 
 :: Train NasNetMobile
-python make_nsfw_model.py --image_dir %cd%\..\images --image_size 224 --saved_model_dir %cd%\..\trained_models\nasnet_a_224 --labels_output_file %cd%\..\trained_models\nasnet_a_224\class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/nasnet_mobile/classification/4 --tflite_output_file %cd%\..\trained_models\nasnet_a_224\saved_model.tflite --train_epochs 5 --batch_size 24 --do_fine_tuning --learning_rate 0.001 --dropout_rate 0.0 --momentum 0.9
-:: Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training.
+python make_nsfw_model.py --image_dir %cd%\..\images --image_size 224 --saved_model_dir %cd%\..\trained_models\nasnet_a_224 --labels_output_file %cd%\..\trained_models\nasnet_a_224\class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/nasnet_mobile/feature_vector/4 --tflite_output_file %cd%\..\trained_models\nasnet_a_224\saved_model.tflite --train_epochs 9001 --batch_size 24 --do_fine_tuning --learning_rate 0.001 --dropout_rate 0.0 --label_smoothing=0.0 --validation_split=0.1 --do_data_augmentation=True --use_mixed_precision=True --rmsprop_momentum=0.0
+:: Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training. So make sure you perform this step after all your training is done, and then restore a GPU version of TF.
 ::tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve %cd%\..\trained_models\nasnet_a_224 %cd%\..\trained_models\nasnet_a_224\web_modely
 :: Or, for a quantized (1 byte) version
 ::tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve %cd%\..\trained_models\nasnet_a_224 %cd%\..\trained_models\nasnet_a_224\web_modely_quantized --quantization_bytes 1

--- a/training/train_all_models.sh
+++ b/training/train_all_models.sh
@@ -1,28 +1,19 @@
 #!/bin/sh
 # You can add more models types from here: https://tfhub.dev/s?module-type=image-classification&tf-version=tf2
 # However, you must choose Tensorflow 2 models. V1 models will not work here.
-# https://tfhub.dev/google/imagenet/mobilenet_v2_140_224/classification/4
-# https://tfhub.dev/google/imagenet/resnet_v2_50/classification/4
-# https://tfhub.dev/google/imagenet/inception_v3/classification/4
-# https://tfhub.dev/google/imagenet/nasnet_mobile/classification/4
-# https://tfhub.dev/tensorflow/efficientnet/b0/classification/1
-#
+# https://tfhub.dev/google/imagenet/mobilenet_v2_140_224/feature_vector/4
+# https://tfhub.dev/google/imagenet/resnet_v2_50/feature_vector/4
+# https://tfhub.dev/google/imagenet/inception_v3/feature_vector/4
+# https://tfhub.dev/google/imagenet/nasnet_mobile/feature_vector/4
+# 
 # If you get CUDA_OUT_OF_MEMORY crash, you need to pass --batch_size NUMBER, reducing until you don't get this error.
 # It is advised by Google not to have a batch size < 8.
 
-# Train EfficientNet B0
-python3 make_nsfw_model.py --image_dir $PWD/../images --image_size 224 --saved_model_dir $PWD/../trained_models/efficientnet_b0_224 --labels_output_file $PWD/../trained_models/efficientnet_b0_224/class_labels.txt --tfhub_module https://tfhub.dev/tensorflow/efficientnet/b0/classification/1 --tflite_output_file $PWD/../trained_models/efficientnet_b0_224/saved_model.tflite --train_epochs 5 --batch_size 16 --do_fine_tuning --learning_rate 0.05 --dropout_rate 0.0 --momentum 0.9
-# Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training.
-# tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/efficientnet_b0_224 $PWD/../trained_models/efficientnet_b0_224/web_model
-# Or, for a quantized (1 byte) version
-# tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/efficientnet_b0_224 $PWD/../trained_models/efficientnet_b0_224/web_model_quantized --quantization_bytes 1
-
-# Wait for Python/CUDA/GPU to recover. Seems to die without this.
-sleep 60
+# Note that we set all of our target epochs to over 9000. This is because the trainer just uses early stopping internally.
 
 # Train Mobilenet V2 140
-python3 make_nsfw_model.py --image_dir $PWD/../images --image_size 224 --saved_model_dir $PWD/../trained_models/mobilenet_v2_140_224 --labels_output_file $PWD/../trained_models/mobilenet_v2_140_224/class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/mobilenet_v2_140_224/classification/4 --tflite_output_file $PWD/../trained_models/mobilenet_v2_140_224/saved_model.tflite --train_epochs 5 --batch_size 32 --do_fine_tuning --learning_rate 0.001 --dropout_rate 0.0 --momentum 0.9
-# Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training.
+python make_nsfw_model.py --image_dir $PWD/../images --image_size 224 --saved_model_dir $PWD/../trained_models/mobilenet_v2_140_224 --labels_output_file $PWD/../trained_models/mobilenet_v2_140_224/class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/mobilenet_v2_140_224/feature_vector/4 --tflite_output_file $PWD/../trained_models/mobilenet_v2_140_224/saved_model.tflite --train_epochs 9001 --batch_size 32 --do_fine_tuning --dropout_rate 0.0 --label_smoothing=0.0 --validation_split=0.1 --do_data_augmentation=True --use_mixed_precision=True --rmsprop_momentum=0.0
+# Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training. So make sure you perform this step after all your training is done, and then restore a GPU version of TF.
 # tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/mobilenet_v2_140_224 $PWD/../trained_models/mobilenet_v2_140_224/web_model
 # Or, for a quantized (1 byte) version
 # tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/mobilenet_v2_140_224 $PWD/../trained_models/mobilenet_v2_140_224/web_model_quantized --quantization_bytes 1
@@ -31,28 +22,28 @@ python3 make_nsfw_model.py --image_dir $PWD/../images --image_size 224 --saved_m
 sleep 60
 
 # Train Resnet V2 50
-python3 make_nsfw_model.py --image_dir $PWD/../images --image_size 224 --saved_model_dir $PWD/../trained_models/resnet_v2_50_224 --labels_output_file $PWD/../trained_models/resnet_v2_50_224/class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/resnet_v2_50/classification/4 --tflite_output_file $PWD/../trained_models/resnet_v2_50_224/saved_model.tflite --train_epochs 5 --batch_size 16 --do_fine_tuning --learning_rate 0.001 --dropout_rate 0.0 --momentum 0.9
-# Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training.
-#tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/resnet_v2_50_224 $PWD/../trained_models/resnet_v2_50_224/web_model
+python make_nsfw_model.py --image_dir $PWD/../images --image_size 224 --saved_model_dir $PWD/../trained_models/resnet_v2_50_224 --labels_output_file $PWD/../trained_models/resnet_v2_50_224/class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/resnet_v2_50/feature_vector/4 --tflite_output_file $PWD/../trained_models/resnet_v2_50_224/saved_model.tflite --train_epochs 9001 --batch_size 16 --do_fine_tuning --learning_rate 0.001 --dropout_rate 0.0 --label_smoothing=0.0 --validation_split=0.1 --do_data_augmentation=True --use_mixed_precision=True --rmsprop_momentum=0.0
+# Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training. So make sure you perform this step after all your training is done, and then restore a GPU version of TF.
+# tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/resnet_v2_50_224 $PWD/../trained_models/resnet_v2_50_224/web_model
 # Or, for a quantized (1 byte) version
-#tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/resnet_v2_50_224 $PWD/../trained_models/resnet_v2_50_224/web_model_quantized --quantization_bytes 1
+# tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/resnet_v2_50_224 $PWD/../trained_models/resnet_v2_50_224/web_model_quantized --quantization_bytes 1
 
 # Wait for Python/CUDA/GPU to recover. Seems to die without this.
 sleep 60
 
 # Train Inception V3
-python3 make_nsfw_model.py --image_dir $PWD/../images --image_size 224 --saved_model_dir $PWD/../trained_models/inception_v3_224 --labels_output_file $PWD/../trained_models/inception_v3_224/class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/inception_v3/classification/4 --tflite_output_file $PWD/../trained_models/inception_v3_224/saved_model.tflite --train_epochs 5 --batch_size 16 --do_fine_tuning --learning_rate 0.001 --dropout_rate 0.0 --momentum 0.9
-# Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training.
-#tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/inception_v3_224 $PWD/../trained_models/inception_v3_224/web_model
+python make_nsfw_model.py --image_dir $PWD/../images --image_size 224 --saved_model_dir $PWD/../trained_models/inception_v3_224 --labels_output_file $PWD/../trained_models/inception_v3_224/class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/inception_v3/feature_vector/4 --tflite_output_file $PWD/../trained_models/inception_v3_224/saved_model.tflite --train_epochs 9001 --batch_size 16 --do_fine_tuning --learning_rate 0.001 --dropout_rate 0.0 --label_smoothing=0.0 --validation_split=0.1 --do_data_augmentation=True --use_mixed_precision=True --rmsprop_momentum=0.0
+# Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training. So make sure you perform this step after all your training is done, and then restore a GPU version of TF.
+# tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/inception_v3_224 $PWD/../trained_models/inception_v3_224/web_model
 # Or, for a quantized (1 byte) version
-#tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/inception_v3_224 $PWD/../trained_models/inception_v3_224/web_model_quantized --quantization_bytes 1
+# tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/inception_v3_224 $PWD/../trained_models/inception_v3_224/web_model_quantized --quantization_bytes 1
 
 # Wait for Python/CUDA/GPU to recover. Seems to die without this.
 sleep 60
 
 # Train NasNetMobile
-python3 make_nsfw_model.py --image_dir $PWD/../images --image_size 224 --saved_model_dir $PWD/../trained_models/nasnet_a_224 --labels_output_file $PWD/../trained_models/nasnet_a_224/class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/nasnet_mobile/classification/4 --tflite_output_file $PWD/../trained_models/nasnet_a_224/saved_model.tflite --train_epochs 5 --batch_size 24 --do_fine_tuning --learning_rate 0.001 --dropout_rate 0.0 --momentum 0.9
-# Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training.
-#tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/nasnet_a_224 $PWD/../trained_models/nasnet_a_224/web_modely
+python make_nsfw_model.py --image_dir $PWD/../images --image_size 224 --saved_model_dir $PWD/../trained_models/nasnet_a_224 --labels_output_file $PWD/../trained_models/nasnet_a_224/class_labels.txt --tfhub_module https://tfhub.dev/google/imagenet/nasnet_mobile/feature_vector/4 --tflite_output_file $PWD/../trained_models/nasnet_a_224/saved_model.tflite --train_epochs 9001 --batch_size 24 --do_fine_tuning --learning_rate 0.001 --dropout_rate 0.0 --label_smoothing=0.0 --validation_split=0.1 --do_data_augmentation=True --use_mixed_precision=True --rmsprop_momentum=0.0
+# Note that installing tensorflowjs also installs tensorflow-cpu A.K.A. bye-bye-training. So make sure you perform this step after all your training is done, and then restore a GPU version of TF.
+# tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/nasnet_a_224 $PWD/../trained_models/nasnet_a_224/web_modely
 # Or, for a quantized (1 byte) version
-#tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/nasnet_a_224 $PWD/../trained_models/nasnet_a_224/web_modely_quantized --quantization_bytes 1
+# tensorflowjs_converter --input_format=tf_saved_model --output_format=tfjs_graph_model --signature_name=serving_default --saved_model_tags=serve $PWD/../trained_models/nasnet_a_224 $PWD/../trained_models/nasnet_a_224/web_modely_quantized --quantization_bytes 1


### PR DESCRIPTION
We can now select our optimizer, configure each optimizer, we have conversion to FP16 (where possible) as an option which improves memory usage during training at the very least. We can now perform image augmentation during training, control label smoothing, etc.

We also automatically and always do early stopping once validation accuracy does not improve, and since I'm an old man with the old memes, I've set the training target epochs to 9001 in the v2 training scripts because early stopping will actually control this.

Basically I brought over a bunch of configuration stuff from automl and merged them in, fulfilling a bunch of TODOs in the original training code that was brought in from tfhub.

Unfortunately, all these new shiny tools didn't improve overall accuracy on newly trained models. Loss was significantly lower however. I'll attach newly trained mobilenet model to this PR later.