### PR TITLE
Use markers in order to use tensorflow_macos on macOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-tensorflow>=2.1.0
+tensorflow>=2.1.0;sys_platform != 'darwin'
+tensorflow_macos>=2.5.0;sys_platform == 'darwin'
 tensorflow-hub==0.7.0
 pillow


### PR DESCRIPTION
Fixes GantMan/nsfw_model#121