### PR TITLE
Use 1.6.4 release of gh-action-pypi-publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,7 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1
+      - uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_TOKEN }}
@@ -96,7 +96,7 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1
+      - uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
[Usage][1] recommends pinning now, and it's a sensible thing to do.

[1]: https://github.com/pypa/gh-action-pypi-publish#usage