### PR TITLE
Enable passing args to tf.k.Model.predict() when calling predict.classify()

### DIFF
--- a/nsfw_detector/predict.py
+++ b/nsfw_detector/predict.py
@@ -57,17 +57,24 @@ def load_model(model_path):
     return model
 
 
-def classify(model, input_paths, image_dim=IMAGE_DIM):
-    """ Classify given a model, input paths (could be single string), and image dimensionality...."""
+def classify(model, input_paths, image_dim=IMAGE_DIM, predict_args={}):
+    """
+    Classify given a model, input paths (could be single string), and image dimensionality.
+    
+    Optionally, pass predict_args that will be passed to tf.keras.Model.predict().
+    """
     images, image_paths = load_images(input_paths, (image_dim, image_dim))
-    probs = classify_nd(model, images)
+    probs = classify_nd(model, images, predict_args)
     return dict(zip(image_paths, probs))
 
 
-def classify_nd(model, nd_images):
-    """ Classify given a model, image array (numpy)...."""
-
-    model_preds = model.predict(nd_images)
+def classify_nd(model, nd_images, predict_args={}):
+    """
+    Classify given a model, image array (numpy)
+    
+    Optionally, pass predict_args that will be passed to tf.keras.Model.predict().
+    """
+    model_preds = model.predict(nd_images, **predict_args)
     # preds = np.argsort(model_preds, axis = 1).tolist()
     
     categories = ['drawings', 'hentai', 'neutral', 'porn', 'sexy']


### PR DESCRIPTION
Fixes #113

This should enable a user to call `predict()` with options passed to [`tf.keras.Model.predict()`](https://www.tensorflow.org/api_docs/python/tf/keras/Model#predict), e.g.

```python
nsfw_detector.predict.classify(model, input_paths, predict_args={'verbose': 0})
```

to disable Keras's progress bar or `2` instead of `0` in production, non-interactive execution.