### PR TITLE
Adds undeclared numpy dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ tensorflow>=2.1.0;sys_platform != 'darwin'
 tensorflow_macos>=2.5.0;sys_platform == 'darwin'
 tensorflow-hub==0.7.0
 pillow
+
+numpy


### PR DESCRIPTION
It was coming in transitively through tensorflow, but it's correct to declare it ourselves without a version bound.
