### PR TITLE
Bump tensorflow minimum requirement to 2.2.0, first with Python 3.8 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow>=2.1.0;sys_platform != 'darwin'
+tensorflow>=2.2.0;sys_platform != 'darwin'
 tensorflow_macos>=2.5.0;sys_platform == 'darwin'
-tensorflow-hub==0.7.0
+tensorflow-hub==0.12.0
 pillow


### PR DESCRIPTION
Also bump tensorflow-hub to the latest

This dovetails off of #133, which bumped the minimum Python to 3.8. The resolver would choose 2.2.0 minimally anyway so let's bump it up for good measure.