### PR TITLE
fix:Update dependencies and lastest model url

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Please feel free to use this model to help your products!
 
 If you'd like to [say thanks for creating this, I'll take a donation for hosting costs](https://www.paypal.me/GantLaborde).
 
-# Latest Models Zip (v1.1.0)
-https://github.com/GantMan/nsfw_model/releases/tag/1.1.0
+# Latest Models Zip (v1.2.0)
+https://github.com/GantMan/nsfw_model/releases/tag/1.2.0
 
 ### Original Inception v3 Model (v1.0)
 * [Keras 299x299 Image Model](https://s3.amazonaws.com/ir_public/ai/nsfw_models/nsfw.299x299.h5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 tensorflow>=2.2.0;sys_platform != 'darwin'
 tensorflow_macos>=2.5.0;sys_platform == 'darwin'
-tensorflow-hub==0.12.0
+tensorflow-hub==0.16.0
 pillow
 
 numpy


### PR DESCRIPTION
I find tensorflow-hub==0.12.0 can't work with Latest tensorflow ，update it to 0.13.0 or higher will solve the problem. And I updated README.md for latest model 1.2.0, it works much better than 1.1.0 